### PR TITLE
crash fix on onHostDestroy fun

### DIFF
--- a/android/src/main/java/com/digioreactnative/DigioReactNativeModule.java
+++ b/android/src/main/java/com/digioreactnative/DigioReactNativeModule.java
@@ -152,8 +152,12 @@ public class DigioReactNativeModule extends ReactContextBaseJavaModule implement
   @Override
   public void onHostDestroy() {
    if (isReceiverRegistered) {
-        this.getReactApplicationContext().unregisterReceiver(eventBroadcastReceiver);
-        isReceiverRegistered = false;
+       try{
+         this.getReactApplicationContext().unregisterReceiver(eventBroadcastReceiver);
+          isReceiverRegistered = false;
+       } catch (IllegalArgumentException e) {
+          Log.w("DigioReactNativeModule", "Receiver not registered", e);
+        }
      }
   }
 


### PR DESCRIPTION
DigioReactNativeModule.onHostDestroy
java.lang.IllegalArgumentException - Receiver not registered: com.digioreactnative.DigioReactNativeModule